### PR TITLE
Clean up orphaned empty CHARTEVENT_OBJECT_DRAG branch in CChartEventR…

### DIFF
--- a/CChartEventRouter.mqh
+++ b/CChartEventRouter.mqh
@@ -61,7 +61,6 @@ public:
             return true;
            }
         }
-
       return false;
      }
   };


### PR DESCRIPTION
Empfehlung
Beste Variante: entfernen

Wenn dort wirklich keine Logik mehr gebraucht wird, dann den Block komplett löschen.

Also statt:

if(id == CHARTEVENT_OBJECT_DRAG)
{
}

einfach nichts.

Das ist die sauberste Lösung.